### PR TITLE
Fixes sqlite3_prepare_v2 definition

### DIFF
--- a/sqlite.mod/common.bmx
+++ b/sqlite.mod/common.bmx
@@ -102,7 +102,7 @@ Const SQLITE_OPEN_EXRESCODE:Int =        $02000000  ' Extended result codes
 Extern
 	Function sqlite3_close:Int(handle:Byte Ptr)
 	Function sqlite3_open_v2:Int(dhname:Byte Ptr, handle:Byte Ptr, flags:Int, fvs:Byte Ptr)
-	Function sqlite3_prepare_v2:Int(dbhandle:Byte Ptr, sql:Byte Ptr, size:Int, stmtHandle:Byte Ptr Ptr, pzTail:Int)
+	Function sqlite3_prepare_v2:Int(dbhandle:Byte Ptr, sql:Byte Ptr, size:Int, stmtHandle:Byte Ptr Ptr, pzTail:Byte Ptr Ptr)
 	Function sqlite3_finalize(stmtHandle:Byte Ptr)
 	Function sqlite3_reset:Int(stmtHandle:Byte Ptr)
 	Function sqlite3_step:Int(stmtHandle:Byte Ptr)

--- a/sqlite.mod/sqlite.bmx
+++ b/sqlite.mod/sqlite.bmx
@@ -566,7 +566,7 @@ Type TSQLiteResultSet Extends TQueryResultSet
 		
 		Local q:Byte Ptr = query.ToUTF8String()
 		
-		Local result:Int = sqlite3_prepare_v2(TDBSQLite(conn).handle, q, _strlen(q) , Varptr stmtHandle, 0)
+		Local result:Int = sqlite3_prepare_v2(TDBSQLite(conn).handle, q, _strlen(q) , Varptr stmtHandle, Null)
 		MemFree(q)
 		If result <> SQLITE_OK Then
 			conn.setError("Error preparing statement", String.FromUTF8String(sqlite3_errmsg(TDBSQLite(conn).handle)), TDatabaseError.ERROR_STATEMENT, result)


### PR DESCRIPTION
Corrects the definition of sqlite3_prepare_v2 by adjusting the type of the `pzTail` parameter.

This resolves potential issues due to type mismatches when calling the function.